### PR TITLE
Add pagination support to the searchCatalog method

### DIFF
--- a/src/AppleMusicAPI.php
+++ b/src/AppleMusicAPI.php
@@ -594,14 +594,22 @@ class AppleMusicAPI
      * @param string $searchTerm The entered text for the search with ‘+’ characters between each word,
      *                           to replace spaces
      * @param string $searchTypes The list of the types of resources to include in the results. artists,albums,songs
+     * @param int $limit The number of objects or number of objects in the specified relationship returned
+     * @param int $offset The next page or group of objects to fetch
      *
      * @return array|object
      *
      * @throws AppleMusicAPIException
      */
-    public function searchCatalog($storefront, $searchTerm, $searchTypes)
+    public function searchCatalog($storefront, $searchTerm, $searchTypes, $limit = 5, $offset = 0)
     {
-        $requestUrl = sprintf('catalog/%s/search?term=%s&types=%s', $storefront, $searchTerm, $searchTypes);
+        $requestUrl = sprintf(
+            'catalog/%s/search?term=%s&types=%s&%s',
+            $storefront,
+            $searchTerm,
+            $searchTypes,
+            $this->getLimitOffsetQueryString($limit, $offset, 25)
+        );
 
         return $this->client->apiRequest('GET', $requestUrl);
     }


### PR DESCRIPTION
Hi, thanks for this great library. Here's a little addition that adds the ability to specify both the limit and offset parameters when searching the Apple Music catalog, which enables pagination.