### PR TITLE
Add support for "isPublic" parameter when creating a library playlist

### DIFF
--- a/src/AppleMusicAPI.php
+++ b/src/AppleMusicAPI.php
@@ -508,7 +508,7 @@ class AppleMusicAPI
         $requestBody['attributes'] = [
             'name' => $playlist->getName(),
             'description' => $playlist->getDescription(),
-            'isPublic' => $playlist->getIsPublic(),
+            'isPublic' => $playlist->isPublic(),
         ];
 
         foreach ($playlist->getTracks() as $track) {

--- a/src/AppleMusicAPI.php
+++ b/src/AppleMusicAPI.php
@@ -508,6 +508,7 @@ class AppleMusicAPI
         $requestBody['attributes'] = [
             'name' => $playlist->getName(),
             'description' => $playlist->getDescription(),
+            'isPublic' => $playlist->getIsPublic(),
         ];
 
         foreach ($playlist->getTracks() as $track) {

--- a/src/Request/LibraryPlaylistCreationRequest.php
+++ b/src/Request/LibraryPlaylistCreationRequest.php
@@ -80,7 +80,7 @@ class LibraryPlaylistCreationRequest
     /**
      * @return bool
      */
-    public function getIsPublic(): bool
+    public function isPublic(): bool
     {
         return $this->isPublic;
     }

--- a/src/Request/LibraryPlaylistCreationRequest.php
+++ b/src/Request/LibraryPlaylistCreationRequest.php
@@ -20,6 +20,11 @@ class LibraryPlaylistCreationRequest
     protected $description = '';
 
     /**
+     * @var bool
+     */
+    protected $isPublic = false;
+
+    /**
      * @var LibraryResource[]
      */
     protected $tracks = [];
@@ -62,6 +67,22 @@ class LibraryPlaylistCreationRequest
     public function getDescription(): string
     {
         return $this->description;
+    }
+
+    /**
+     * @param bool $isPublic
+     */
+    public function setIsPublic(bool $isPublic): void
+    {
+        $this->isPublic = $isPublic;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsPublic(): bool
+    {
+        return $this->isPublic;
     }
 
     /**


### PR DESCRIPTION
`isPublic` parameter is not documented in the API but can be found when inspecting the requests of Apple Music web version. It allows to automatically publish a playlist to the user's profile & search. 

Thanks to it, it's also possible to retrieve the `globalId` of a playlist inside the return of the playlist creation endpoint. Without this option, you had to go to the Apple Music UI, manually mark the playlist as public (or click on the share button), which would generate a `globalId` you could then retrieve with a `getLibraryPlaylist`. 