### PR TITLE
Allow Symfony 8

### DIFF
--- a/.github/workflows/build-project-actions.yml
+++ b/.github/workflows/build-project-actions.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-project-actions.yml
+++ b/.github/workflows/build-project-actions.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "symfony/http-client": "^6|^7",
+        "symfony/http-client": "^6|^7|^8",
         "web-token/jwt-library": "^3.0|^4.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     "homepage": "https://github.com/PouleR/apple-music-api",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^10",
-        "squizlabs/php_codesniffer": "^3.0"
+        "phpunit/phpunit": "^12",
+        "squizlabs/php_codesniffer": "^4"
     },
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
         "symfony/http-client": "^6|^7|^8",
-        "web-token/jwt-library": "^3.0|^4.0"
+        "web-token/jwt-library": "^3|^4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "squizlabs/php_codesniffer": "^4"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "ext-json": "*",
         "symfony/http-client": "^6|^7|^8",
         "web-token/jwt-library": "^3|^4"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <coverage/>
   <testsuites>
     <testsuite name="Apple Music API tests">
-      <directory suffix="Test.php">./tests/</directory>
+      <directory>./tests/</directory>
     </testsuite>
   </testsuites>
   <source>

--- a/tests/APIClientTest.php
+++ b/tests/APIClientTest.php
@@ -28,7 +28,7 @@ class APIClientTest extends TestCase
 
         $requestOptions = $mockResponse->getRequestOptions();
         self::assertContains('Authorization: Bearer dev.token', $requestOptions['headers']);
-        self::assertEquals('12345', $response->id);
+        self::assertSame('12345', $response->id);
     }
 
     /**
@@ -47,7 +47,7 @@ class APIClientTest extends TestCase
 
         self::assertContains('Authorization: Bearer dev.token', $requestOptions['headers']);
         self::assertContains('Music-User-Token: user.token', $requestOptions['headers']);
-        self::assertEquals('UserToken', $response->title);
+        self::assertSame('UserToken', $response->title);
     }
 
     /**
@@ -78,9 +78,9 @@ class APIClientTest extends TestCase
     {
         $httpClient = new MockHttpClient();
         $apiClient = new APIClient($httpClient);
-        self::assertEquals(APIClient::RETURN_AS_OBJECT, $apiClient->getResponseType());
+        self::assertSame(APIClient::RETURN_AS_OBJECT, $apiClient->getResponseType());
 
         $apiClient->setResponseType(APIClient::RETURN_AS_ASSOC);
-        self::assertEquals(APIClient::RETURN_AS_ASSOC, $apiClient->getResponseType());
+        self::assertSame(APIClient::RETURN_AS_ASSOC, $apiClient->getResponseType());
     }
 }

--- a/tests/AppleMusicAPITest.php
+++ b/tests/AppleMusicAPITest.php
@@ -37,14 +37,6 @@ class AppleMusicAPITest extends TestCase
     /**
      *
      */
-    public function testAPIClient(): void
-    {
-        self::assertEquals($this->client, $this->api->getAPIClient());
-    }
-
-    /**
-     *
-     */
     public function testDeveloperToken(): void
     {
         $this->client->expects(static::once())
@@ -76,7 +68,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'catalog/nl/charts?types=albums%2Csongs&offset=0&limit=15&genre=20')
             ->willReturn('{"OK"}');
 
-        self::assertEquals(
+        self::assertSame(
             '{"OK"}',
             $this->api->getCatalogCharts('nl', ['albums', 'songs'], 20, 15)
         );
@@ -92,7 +84,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'catalog/us/playlists/pl.12345')
             ->willReturn('{"OK"}');
 
-        self::assertEquals(
+        self::assertSame(
             '{"OK"}',
             $this->api->getCatalogPlaylist('us', 'pl.12345')
         );
@@ -108,7 +100,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'catalog/us/albums/test')
             ->willReturn('{"OK"}');
 
-        self::assertEquals(
+        self::assertSame(
             '{"OK"}',
             $this->api->getCatalogAlbum('us', 'test')
         );
@@ -124,7 +116,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'catalog/us/songs/song.id')
             ->willReturn('{"OK"}');
 
-        self::assertEquals(
+        self::assertSame(
             '{"OK"}',
             $this->api->getCatalogSong('us', 'song.id')
         );
@@ -140,7 +132,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'catalog/us/artists/artist.id')
             ->willReturn('{"OK"}');
 
-        self::assertEquals(
+        self::assertSame(
             '{"OK"}',
             $this->api->getCatalogArtist('us', 'artist.id')
         );
@@ -156,7 +148,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'me/storefront')
             ->willReturn('us');
 
-        self::assertEquals(
+        self::assertSame(
             'us',
             $this->api->getUsersStorefront()
         );
@@ -172,7 +164,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'me/recent/played?offset=5&limit=10')
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->getRecentlyPlayedResources(250, 5)
         );
@@ -188,7 +180,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'me/library/playlists?offset=3&limit=100')
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->getAllLibraryPlaylists(500, 3)
         );
@@ -204,7 +196,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'me/library/albums?offset=0&limit=25')
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->getAllLibraryAlbums()
         );
@@ -220,7 +212,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'me/library/artists?offset=0&limit=20')
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->getAllLibraryArtists(20)
         );
@@ -236,7 +228,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'me/library/music-videos?offset=10&limit=10')
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->getAllLibraryMusicVideos(10, 10)
         );
@@ -257,7 +249,7 @@ class AppleMusicAPITest extends TestCase
             ->with('POST', 'me/library?ids[songs]=123,888&ids[albums]=456', [], ' ')
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->addResourceToLibrary($request)
         );
@@ -287,7 +279,7 @@ class AppleMusicAPITest extends TestCase
             )
             ->willReturn('OK');
 
-        self::assertEquals(
+        self::assertSame(
             'OK',
             $this->api->createLibraryPlaylist($playlist)
         );
@@ -303,7 +295,7 @@ class AppleMusicAPITest extends TestCase
             ->with('GET', 'catalog/us/search?term=search&types=songs&offset=0&limit=5')
             ->willReturn('{"Search"}');
 
-        self::assertEquals(
+        self::assertSame(
             '{"Search"}',
             $this->api->searchCatalog('us', 'search', 'songs')
         );


### PR DESCRIPTION
- Allow Symfony 8
- Update to PHPUnit 12
- Remove support of PHP 8.1 and PHP 8.2